### PR TITLE
Configure GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install wasm-pack
+        run: |
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build wasm package
+        run: wasm-pack build --target web wasm_game
+      - name: Build Jekyll site
+        run: bundle exec jekyll build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+

--- a/decisiones/20250630-configurar-gh-actions.md
+++ b/decisiones/20250630-configurar-gh-actions.md
@@ -1,0 +1,17 @@
+# Configurar GitHub Actions
+
+## Resumen
+Se agregó un flujo de trabajo en `.github/workflows/build.yml` que configura Rust y Node, compila el proyecto WebAssembly con `wasm-pack`, construye el sitio con Jekyll y despliega a `gh-pages`.
+
+## Razonamiento
+Es necesario automatizar la generación y despliegue del videojuego y la página. Un flujo de trabajo centralizado reduce errores y asegura que la versión en `gh-pages` esté actualizada.
+
+## Alternativas consideradas
+- Usar solo compilaciones locales: descartado por ser propenso a fallos humanos.
+- Emplear otro action para despliegue: se consideró `actions/deploy-pages`, pero se eligió `peaceiris/actions-gh-pages` por su facilidad y uso extendido.
+
+## Sugerencias
+La configuración podría ampliarse para ejecutar pruebas automáticas y publicar artefactos del juego. Futuras mejoras pueden incluir manejo de versiones y deploy condicional según entornos.
+
+###SHA
+8da1e6b23a4dbbc499d6e6a05d9e7635ea3e9376


### PR DESCRIPTION
## Summary
- add build workflow for Rust & Node game build
- document GitHub Actions setup decision

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862535dca6c833183eb0be74a3e9663