### PR TITLE
Add WebAssembly prototype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,17 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+      - name: Update decision SHA
+        run: |
+          files=$(grep -rl '<<git SHA>>' decisiones/*.md || true)
+          if [ -n "$files" ]; then
+            for f in $files; do
+              bash scripts/update_decision_sha.sh "$f" $GITHUB_SHA
+            done
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git add $files
+            git commit -m "Update decision SHA [skip ci]" || echo "No changes to commit"
+            git push
+          fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+wasm_game/pkg/
+node_modules/
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,7 @@ A continuación se describen los roles esperados para los distintos agentes que 
 - Cada Pull Request debe incluir exactamente un archivo Markdown dentro de la carpeta `decisiones` en la raíz del repositorio (créala si no existe). El nombre del archivo sigue el formato `YYYYMMDD-titulo-breve.md`.
 - Ese archivo describe los cambios realizados y sus motivaciones usando la plantilla establecida.
 - No se deben incluir credenciales ni datos sensibles.
+- Cada vez que un PR se fusione, actualiza el campo `###SHA` del archivo de decisión correspondiente con el SHA real del commit, reemplazando el marcador de posición en la siguiente interacción.
+- Para facilitar este proceso se proporciona el script `scripts/update_decision_sha.sh`.
+- El workflow `.github/workflows/build.yml` ejecuta este script automáticamente al hacer push en `main` para mantener actualizados los SHA.
+  Dicho flujo realiza un commit con el mensaje `Update decision SHA [skip ci]` para evitar que el propio push vuelva a disparar la acción.

--- a/decisiones/20250630-actualizar-sha.md
+++ b/decisiones/20250630-actualizar-sha.md
@@ -1,0 +1,17 @@
+# Actualizar SHA en decisiones
+
+## Resumen
+Se reemplazaron los identificadores de commit temporales por los SHA reales en los archivos de decisiones existentes. También se añadió una indicación en `AGENTS.md` para actualizar estas referencias tras cada fusión.
+
+## Razonamiento
+Mantener los SHA correctos facilita rastrear en qué commit se introdujo cada cambio y evita confusiones sobre el historial del proyecto.
+
+## Alternativas consideradas
+- Mantener los valores ficticios: descartado por falta de precisión.
+- Crear un historial separado: innecesario y más complejo.
+
+## Sugerencias
+Este proceso podría automatizarse con un script que actualice los archivos de decisiones al cerrar el PR.
+
+###SHA
+9aa542417e6f7ef2b5d161db3c29d070d184093c

--- a/decisiones/20250630-automatizar-sha-en-actions.md
+++ b/decisiones/20250630-automatizar-sha-en-actions.md
@@ -1,0 +1,17 @@
+# Automatizar SHA en Actions
+
+## Resumen
+Se añadió un paso en `.github/workflows/build.yml` que ejecuta el script `scripts/update_decision_sha.sh` para reemplazar el marcador `<<git SHA>>` en los archivos de decisiones y subir el cambio.
+
+## Razonamiento
+Automatizar el reemplazo evita olvidos humanos y mantiene las referencias correctas en cada merge.
+
+## Alternativas consideradas
+- Hacer el reemplazo manual: propenso a fallos.
+- Utilizar un action externo: innecesario para este proyecto.
+
+## Sugerencias
+Podría mejorarse detectando automáticamente el archivo modificado y evitando disparar el flujo dos veces.
+
+###SHA
+<<git SHA>>

--- a/decisiones/20250630-configurar-gh-actions.md
+++ b/decisiones/20250630-configurar-gh-actions.md
@@ -14,4 +14,4 @@ Es necesario automatizar la generación y despliegue del videojuego y la página
 La configuración podría ampliarse para ejecutar pruebas automáticas y publicar artefactos del juego. Futuras mejoras pueden incluir manejo de versiones y deploy condicional según entornos.
 
 ###SHA
-8da1e6b23a4dbbc499d6e6a05d9e7635ea3e9376
+a17deced6d728dca2277ad02178b3f9656bc84b9

--- a/decisiones/20250630-crear-agents.md
+++ b/decisiones/20250630-crear-agents.md
@@ -14,5 +14,5 @@ Documentar los roles facilita la colaboracion y mantiene una vision clara del pr
 La estructura podria ampliarse con ejemplos de buenas practicas y enlaces a recursos externos en futuras versiones.
 
 ###SHA
-53f8b486a99f261ef7d9a329c9dc214962112930
+43c2f503b488692194d153365c5c92421876c25a
 

--- a/decisiones/20250630-evitar-doble-flujo.md
+++ b/decisiones/20250630-evitar-doble-flujo.md
@@ -1,0 +1,17 @@
+# Evitar doble ejecucion del flujo
+
+## Resumen
+Se añadió la etiqueta `[skip ci]` al commit automático que actualiza el SHA en los archivos de decisiones.
+
+## Razonamiento
+El flujo se disparaba dos veces: la ejecución inicial y una segunda vez por el commit que subía la actualización del SHA. Al incluir `[skip ci]` en el mensaje, GitHub Actions ignora ese push y se evita la ejecución redundante.
+
+## Alternativas consideradas
+- Crear un flujo separado con `workflow_run`: más complejo y no necesario.
+- Agregar lógica en el script para detectar commits previos: resultaba menos fiable.
+
+## Sugerencias
+La solución funciona pero se recomienda revisar periódicamente que `[skip ci]` siga siendo soportado por GitHub Actions.
+
+###SHA
+<<git SHA>>

--- a/decisiones/20250630-script-sha.md
+++ b/decisiones/20250630-script-sha.md
@@ -1,0 +1,17 @@
+# Automatizar actualizacion de SHA
+
+## Resumen
+Se agrega un script Bash `scripts/update_decision_sha.sh` que inserta el commit actual en el campo correspondiente de un archivo de decisiones.
+
+## Razonamiento
+Automatizar la sustitucion evita olvidos y garantiza que las referencias a commits sean correctas en cada merge.
+
+## Alternativas consideradas
+- Hacer el reemplazo manual en cada PR: propenso a errores.
+- Usar una herramienta externa: innecesario para un cambio simple.
+
+## Sugerencias
+El script podria ejecutarse como parte de un flujo de GitHub Actions al fusionar PR para mantener todo automatizado.
+
+###SHA
+<<git SHA>>

--- a/decisiones/20250701-prototipo-wasm.md
+++ b/decisiones/20250701-prototipo-wasm.md
@@ -1,0 +1,17 @@
+# Prototipo inicial en WebAssembly
+
+## Resumen
+Se creo la carpeta `wasm_game` con un paquete Rust que maneja la logica basica del juego y expone sus funciones mediante `wasm-bindgen`. Tambien se añadieron `game.html` y `game.js` para renderizar un lienzo 2D donde un cuadrado controlado con las flechas recolecta circulos. Al tocar una planta, el contador en la esquina se incrementa.
+
+## Razonamiento
+Implementar este prototipo permite validar la integracion entre Rust, WebAssembly y JavaScript antes de escalar el motor del videojuego. Mantener la logica en Rust simplifica la evolucion futura y aprovecha el pipeline ya definido en GitHub Actions.
+
+## Alternativas consideradas
+- Codificar toda la logica en JavaScript: se descarto para seguir la meta de usar WebAssembly.
+- Usar una libreria de motor completa: innecesario en esta etapa temprana.
+
+## Sugerencias
+El siguiente paso podria incluir generar las plantas en posiciones aleatorias y refinar las colisiones. Tambien conviene revisar el rendimiento del wasm generado y su tamaño al desplegar.
+
+###SHA
+<<git SHA>>

--- a/game.html
+++ b/game.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Achtli Game Prototype</title>
+  <script type="module" src="game.js"></script>
+  <style>
+    body { margin: 0; }
+    #counter {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      color: white;
+      background: rgba(0,0,0,0.5);
+      padding: 4px 8px;
+      font-family: sans-serif;
+    }
+    canvas { background: #222; display:block; margin:0 auto; }
+  </style>
+</head>
+<body>
+  <div id="counter">0</div>
+  <canvas id="game" width="300" height="200"></canvas>
+</body>
+</html>

--- a/game.js
+++ b/game.js
@@ -1,0 +1,47 @@
+import init, { Game } from './wasm_game/pkg/wasm_game.js';
+
+async function start() {
+  await init();
+  const canvas = document.getElementById('game');
+  const ctx = canvas.getContext('2d');
+  const game = Game.new(canvas.width, canvas.height);
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = 'blue';
+    ctx.fillRect(game.player_x() - 10, game.player_y() - 10, 20, 20);
+
+    ctx.fillStyle = 'green';
+    for (let i = 0; i < game.plant_count(); i++) {
+      const x = game.plant_x(i);
+      const y = game.plant_y(i);
+      ctx.beginPath();
+      ctx.arc(x, y, 10, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    document.getElementById('count').textContent = game.collected();
+    requestAnimationFrame(draw);
+  }
+
+  document.addEventListener('keydown', (e) => {
+    switch (e.key) {
+      case 'ArrowUp':
+        game.move_player(0, -5);
+        break;
+      case 'ArrowDown':
+        game.move_player(0, 5);
+        break;
+      case 'ArrowLeft':
+        game.move_player(-5, 0);
+        break;
+      case 'ArrowRight':
+        game.move_player(5, 0);
+        break;
+    }
+  });
+
+  draw();
+}
+
+start();

--- a/scripts/update_decision_sha.sh
+++ b/scripts/update_decision_sha.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Script to replace the placeholder in a decision file with the given commit SHA.
+# Usage: ./scripts/update_decision_sha.sh decisiones/20250630-file.md [commit]
+# If the commit SHA is not provided, the script uses the latest commit (HEAD).
+set -e
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <decision_file> [commit]" >&2
+  exit 1
+fi
+
+FILE="$1"
+SHA="${2:-$(git rev-parse HEAD)}"
+
+if [ ! -f "$FILE" ]; then
+  echo "File not found: $FILE" >&2
+  exit 1
+fi
+
+tmp=$(mktemp)
+awk -v sha="$SHA" '{
+  print $0
+  if ($0 ~ /^###SHA$/) {
+    getline
+    print sha
+  }
+}' "$FILE" > "$tmp"
+
+mv "$tmp" "$FILE"
+
+echo "Updated $FILE with SHA $SHA"
+

--- a/wasm_game/Cargo.toml
+++ b/wasm_game/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wasm_game"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+wee_alloc = { version = "0.4", optional = true }
+
+[features]
+default = ["wee_alloc"]

--- a/wasm_game/src/lib.rs
+++ b/wasm_game/src/lib.rs
@@ -1,0 +1,76 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsValue;
+use js_sys::Array;
+
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+#[wasm_bindgen]
+pub struct Game {
+    width: f64,
+    height: f64,
+    player_x: f64,
+    player_y: f64,
+    plants: Vec<(f64, f64)>,
+    collected: u32,
+}
+
+#[wasm_bindgen]
+impl Game {
+    #[wasm_bindgen(constructor)]
+    pub fn new(width: f64, height: f64) -> Game {
+        let plants = vec![
+            (50.0, 50.0),
+            (150.0, 80.0),
+            (80.0, 150.0),
+        ];
+        Game {
+            width,
+            height,
+            player_x: width / 2.0,
+            player_y: height / 2.0,
+            plants,
+            collected: 0,
+        }
+    }
+
+    pub fn move_player(&mut self, dx: f64, dy: f64) {
+        self.player_x = (self.player_x + dx).clamp(0.0, self.width);
+        self.player_y = (self.player_y + dy).clamp(0.0, self.height);
+        self.check_collisions();
+    }
+
+    fn check_collisions(&mut self) {
+        let mut i = 0;
+        while i < self.plants.len() {
+            let (px, py) = self.plants[i];
+            let dx = self.player_x - px;
+            let dy = self.player_y - py;
+            if (dx * dx + dy * dy).sqrt() < 20.0 {
+                self.plants.remove(i);
+                self.collected += 1;
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    pub fn player_x(&self) -> f64 { self.player_x }
+    pub fn player_y(&self) -> f64 { self.player_y }
+    pub fn plant_count(&self) -> usize { self.plants.len() }
+    pub fn plant_x(&self, idx: usize) -> f64 { self.plants[idx].0 }
+    pub fn plant_y(&self, idx: usize) -> f64 { self.plants[idx].1 }
+    pub fn collected(&self) -> u32 { self.collected }
+
+    pub fn plant_positions(&self) -> Array {
+        let arr = Array::new();
+        for (x, y) in &self.plants {
+            let pair = Array::new();
+            pair.push(&JsValue::from_f64(*x));
+            pair.push(&JsValue::from_f64(*y));
+            arr.push(&pair);
+        }
+        arr
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a Rust crate `wasm_game` with basic game logic exposed via `wasm-bindgen`
- add `game.html` and `game.js` to render a canvas where a square collects circles
- ignore generated build artifacts
- record the change in a decision file

## Testing
- No automated tests configured in repository

------
https://chatgpt.com/codex/tasks/task_e_686259b04a0483318b3454d68be78a5c