### PR TITLE
Fix counter element and build config

### DIFF
--- a/decisiones/20250702-fix-counter.md
+++ b/decisiones/20250702-fix-counter.md
@@ -1,0 +1,17 @@
+# Corregir contador en game.js
+
+## Resumen
+Se actualizó el código JavaScript para usar el identificador correcto del elemento que muestra el número de plantas recolectadas. También se deshabilitó `wasm-opt` en `Cargo.toml` para evitar fallos al compilar sin acceso a Binaryen.
+
+## Razonamiento
+El contador no se actualizaba porque el script buscaba un elemento `id="count"` inexistente, lo que generaba un error y detenía la animación. La compilación de `wasm-pack` fallaba al intentar descargar `binaryen`; al desactivar `wasm-opt` el proceso concluye con éxito.
+
+## Alternativas consideradas
+- Crear un elemento con `id="count"` en el HTML: descarta do para mantener coherencia con el código existente.
+- Mantener `wasm-opt` habilitado y agregar el binario manualmente: poco práctico en entornos sin red.
+
+## Sugerencias
+El prototipo debería incluir pruebas automáticas de compilación para detectar este tipo de errores. También convendría documentar cómo ejecutar `wasm-pack` sin optimización.
+
+###SHA
+<<git SHA>>

--- a/game.js
+++ b/game.js
@@ -20,7 +20,7 @@ async function start() {
       ctx.fill();
     }
 
-    document.getElementById('count').textContent = game.collected();
+    document.getElementById('counter').textContent = game.collected();
     requestAnimationFrame(draw);
   }
 

--- a/wasm_game/Cargo.toml
+++ b/wasm_game/Cargo.toml
@@ -13,3 +13,6 @@ wee_alloc = { version = "0.4", optional = true }
 
 [features]
 default = ["wee_alloc"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false


### PR DESCRIPTION
## Summary
- reference correct `counter` element in the game script so the canvas updates
- disable `wasm-opt` in build config to avoid network failures
- log decision

## Testing
- `wasm-pack build --target web wasm_game`

------
https://chatgpt.com/codex/tasks/task_e_686264c6b494833199b65b52d28e28aa