### PR TITLE
Add JS fallback for game demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Achtli
-Este es un proyecto que busca recuperar la memoria mexica por medio del rescate al medio ambiente
+Este es un proyecto que busca recuperar la memoria mexica por medio del rescate al medio ambiente.
+
+## Ejecutar el prototipo
+
+Para que el lienzo muestre al jugador en movimiento es necesario compilar el paquete WebAssembly:
+
+```bash
+wasm-pack build --target web wasm_game
+```
+
+Si la compilación no está disponible, el juego utiliza una versión en JavaScript puro como respaldo.
+
+Abre `game.html` en un navegador moderno y usa las flechas para mover al personaje.
 
 cambios por añadir:
 

--- a/decisiones/20250703-js-fallback.md
+++ b/decisiones/20250703-js-fallback.md
@@ -1,0 +1,17 @@
+# Fallback JS para el prototipo
+
+## Resumen
+Se implementó una versión en JavaScript del juego que se usa cuando el módulo WebAssembly no está disponible. Se añadió un atributo de accesibilidad al canvas y se actualizó la documentación con instrucciones de compilación.
+
+## Razonamiento
+Al no compilar el paquete `wasm_game` el sitio sólo mostraba un cuadro negro. Con el respaldo en JS el jugador siempre se ve y se mueve, garantizando funcionalidad básica.
+
+## Alternativas consideradas
+- Incluir los archivos generados por `wasm-pack` en el repositorio: aumenta el peso sin aportar a largo plazo.
+- Omitir la versión wasm y trabajar solo con JS: se perdería el objetivo de aprender WebAssembly.
+
+## Sugerencias
+Automatizar la compilación localmente y ampliar las pruebas de accesibilidad.
+
+###SHA
+<<git SHA>>

--- a/game.html
+++ b/game.html
@@ -20,6 +20,6 @@
 </head>
 <body>
   <div id="counter">0</div>
-  <canvas id="game" width="300" height="200"></canvas>
+  <canvas id="game" width="300" height="200" aria-label="Juego en desarrollo" tabindex="0"></canvas>
 </body>
 </html>

--- a/game.js
+++ b/game.js
@@ -1,10 +1,64 @@
-import init, { Game } from './wasm_game/pkg/wasm_game.js';
+let WasmGame;
+let initWasm;
+
+class JsGame {
+  constructor(width, height) {
+    this.width = width;
+    this.height = height;
+    this.x = width / 2;
+    this.y = height / 2;
+    this.plants = [
+      { x: 50, y: 50 },
+      { x: 150, y: 80 },
+      { x: 80, y: 150 }
+    ];
+    this.collected = 0;
+  }
+
+  move_player(dx, dy) {
+    this.x = Math.min(Math.max(this.x + dx, 0), this.width);
+    this.y = Math.min(Math.max(this.y + dy, 0), this.height);
+    this.#checkCollisions();
+  }
+
+  #checkCollisions() {
+    let i = 0;
+    while (i < this.plants.length) {
+      const p = this.plants[i];
+      const dx = this.x - p.x;
+      const dy = this.y - p.y;
+      if (Math.hypot(dx, dy) < 20) {
+        this.plants.splice(i, 1);
+        this.collected += 1;
+      } else {
+        i++;
+      }
+    }
+  }
+
+  player_x() { return this.x; }
+  player_y() { return this.y; }
+  plant_count() { return this.plants.length; }
+  plant_x(i) { return this.plants[i].x; }
+  plant_y(i) { return this.plants[i].y; }
+  collected() { return this.collected; }
+}
 
 async function start() {
-  await init();
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
-  const game = Game.new(canvas.width, canvas.height);
+  let game;
+
+  try {
+    const wasm = await import('./wasm_game/pkg/wasm_game.js');
+    initWasm = wasm.default;
+    WasmGame = wasm.Game;
+    await initWasm();
+    game = WasmGame.new(canvas.width, canvas.height);
+  } catch (e) {
+    console.warn('WASM failed, falling back to JS implementation', e);
+    game = new JsGame(canvas.width, canvas.height);
+  }
 
   function draw() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
## Summary
- add JavaScript fallback for the game when WASM isn't built
- make canvas keyboard accessible
- document how to build the wasm package
- record decision about the fallback implementation

## Testing
- `node --check game.js`
- `cargo check --manifest-path wasm_game/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68627101a0108331ac3c885c14713ead