### PR TITLE
Fix Rust action in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-rust@v1
+      - uses: rust-lang/setup-rust@v1
         with:
           rust-version: stable
       - uses: actions/setup-node@v4

--- a/decisiones/20250705-rust-action.md
+++ b/decisiones/20250705-rust-action.md
@@ -1,0 +1,17 @@
+# Corregir action de Rust
+
+## Resumen
+Se actualizo la configuracion del workflow para usar `rust-lang/setup-rust@v1` en lugar de `actions/setup-rust@v1`.
+
+## Razonamiento
+La accion anterior no existe y producia el error "Unable to resolve action actions/setup-rust@v1" impidiendo compilar el paquete WASM y desplegar la pagina.
+
+## Alternativas consideradas
+- Instalar Rust manualmente con scripts: mas complejo y propenso a fallos.
+- Usar `actions-rs/toolchain`: requiere mas configuracion especifica para wasm.
+
+## Sugerencias
+Futuras mejoras podrian integrar pruebas automatizadas para verificar la construccion del juego y agregar soporte para varias versiones de Rust.
+
+###SHA
+<<git SHA>>


### PR DESCRIPTION
## Summary
- use rust-lang/setup-rust in build workflow
- add decision record for the change

## Testing
- `wasm-pack build --target web wasm_game` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627e41ac608331a2cd0fe6f0b97683