### PR TITLE
Implement movable square on canvas

### DIFF
--- a/decisiones/20250709-cuadro-controlable.md
+++ b/decisiones/20250709-cuadro-controlable.md
@@ -1,0 +1,17 @@
+# Añadir cuadrado controlable
+
+## Resumen
+Se actualizó `game.js` para mostrar un cuadrado azul que se mueve con las flechas del teclado.
+
+## Razonamiento
+El prototipo solo dibujaba un fondo rosa sin interacción. Con el cuadrado controlable se demuestra la integración básica de controles y animación.
+
+## Alternativas consideradas
+- Mantener el fondo estático: no permitía probar la jugabilidad.
+- Implementar todo en WebAssembly: requiere más trabajo y no era necesario para esta prueba.
+
+## Sugerencias
+El movimiento podría ampliarse para incluir límites más suaves y animaciones. También conviene revisar la compatibilidad con dispositivos móviles.
+
+###SHA
+<<git SHA>>

--- a/game.js
+++ b/game.js
@@ -10,15 +10,56 @@ async function start() {
   resize();
   window.addEventListener('resize', resize);
 
+  let wasmModule = null;
   try {
     const wasm = await import('./wasm_game/pkg/wasm_game.js');
     await wasm.default();
     wasm.draw_pink();
+    wasmModule = wasm;
   } catch (e) {
     console.warn('WASM failed, drawing pink with JS', e);
-    ctx.fillStyle = 'pink';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
   }
+
+  const player = { x: canvas.width / 2 - 10, y: canvas.height / 2 - 10, size: 20 };
+  const speed = 5;
+
+  canvas.focus();
+  canvas.addEventListener('keydown', (e) => {
+    switch (e.key) {
+      case 'ArrowUp':
+        e.preventDefault();
+        player.y = Math.max(0, player.y - speed);
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        player.y = Math.min(canvas.height - player.size, player.y + speed);
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        player.x = Math.max(0, player.x - speed);
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        player.x = Math.min(canvas.width - player.size, player.x + speed);
+        break;
+    }
+  });
+
+  function draw() {
+    if (wasmModule) {
+      wasmModule.draw_pink();
+    } else {
+      ctx.fillStyle = 'pink';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+
+    ctx.fillStyle = 'blue';
+    ctx.fillRect(player.x, player.y, player.size, player.size);
+
+    requestAnimationFrame(draw);
+  }
+
+  draw();
 }
 
 start();


### PR DESCRIPTION
## Summary
- add a simple square controlled with arrow keys
- document the decision in `decisiones/`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6862c6159c6083318e121a34aa2bcbd2