### PR TITLE
Add mobile pointer controls

### DIFF
--- a/decisiones/20250710-controles-tactiles.md
+++ b/decisiones/20250710-controles-tactiles.md
@@ -1,0 +1,17 @@
+# Controles tactiles
+
+## Resumen
+Se añadio `touch-action: none` en `style.css` y se implementaron eventos de puntero en `game.js` para mover al jugador con arrastres.
+
+## Razonamiento
+Estas mejoras permiten controlar el juego en dispositivos moviles sin desplazamiento de la pagina y manteniendo los controles de teclado para escritorio.
+
+## Alternativas consideradas
+- Mantener solo controles de teclado: no funcionaria en pantallas tactiles.
+- Usar eventos `touchstart` y similares: menos consistente que los eventos de puntero.
+
+## Sugerencias
+Se podria añadir retroalimentacion visual al tocar el lienzo y ajustar la sensibilidad del arrastre.
+
+###SHA
+<<git SHA>>

--- a/game.js
+++ b/game.js
@@ -45,6 +45,34 @@ async function start() {
     }
   });
 
+  let dragging = false;
+  let lastX = 0;
+  let lastY = 0;
+
+  canvas.addEventListener('pointerdown', (e) => {
+    dragging = true;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    canvas.setPointerCapture(e.pointerId);
+  });
+
+  canvas.addEventListener('pointermove', (e) => {
+    if (!dragging) return;
+    const dx = e.clientX - lastX;
+    const dy = e.clientY - lastY;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    player.x = Math.max(0, Math.min(canvas.width - player.size, player.x + dx));
+    player.y = Math.max(0, Math.min(canvas.height - player.size, player.y + dy));
+  });
+
+  function endDrag() {
+    dragging = false;
+  }
+
+  canvas.addEventListener('pointerup', endDrag);
+  canvas.addEventListener('pointercancel', endDrag);
+
   function draw() {
     if (wasmModule) {
       wasmModule.draw_pink();

--- a/style.css
+++ b/style.css
@@ -23,3 +23,7 @@ img{
   width:  100%;
   height: auto;
 }
+
+canvas {
+  touch-action: none;
+}


### PR DESCRIPTION
## Summary
- prevent page scrolling when touching the canvas
- allow moving the player by dragging on the canvas
- document touch controls in decisiones

## Testing
- `bundle exec jekyll build --trace`

------
https://chatgpt.com/codex/tasks/task_e_6862cd2813f88331a690321a764ee9df