### PR TITLE
Grant actions write permissions to push updated SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [main]

--- a/decisiones/20250630-permisos-escritura-actions.md
+++ b/decisiones/20250630-permisos-escritura-actions.md
@@ -1,0 +1,17 @@
+# Permitir escritura a acciones
+
+## Resumen
+Se añadió la sección `permissions` con `contents: write` al flujo de trabajo de GitHub Actions.
+
+## Razonamiento
+El bot `github-actions` necesita permiso de escritura para poder actualizar los archivos de decisiones con el SHA del commit y hacer push a `main`.
+
+## Alternativas consideradas
+- Mantener los permisos por defecto: provoca errores al intentar empujar cambios.
+- Crear un token personal: requiere manejo adicional de secretos.
+
+## Sugerencias
+Revisar si otros flujos requieren permisos similares para evitar fallos en futuras automatizaciones.
+
+###SHA
+<<git SHA>>


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push updates by granting `contents: write`
- document the new permission in a decision record

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862d59e6c748331ac6609c94e04a619