### PR TITLE
Fix mobile drag fallback

### DIFF
--- a/decisiones/20250712-fix-touch-fallback.md
+++ b/decisiones/20250712-fix-touch-fallback.md
@@ -1,0 +1,17 @@
+# Mejora de controles táctiles
+
+## Resumen
+Se añadió un sistema alternativo basado en eventos `touchstart` y `touchmove` cuando los eventos de puntero no están disponibles. Con esto el jugador puede arrastrar el cuadrado en dispositivos antiguos o navegadores sin soporte de Pointer Events.
+
+## Razonamiento
+Usuarios reportaron que el arrastre no funcionaba en algunos móviles. Detectamos que ciertos navegadores carecen de soporte para Pointer Events. Al ofrecer un respaldo con eventos táctiles se garantiza la compatibilidad.
+
+## Alternativas consideradas
+- Mantener solo Pointer Events: sigue fallando en navegadores sin soporte.
+- Reescribir todo a touch events: perdería compatibilidad con escritorio.
+
+## Sugerencias
+Realizar pruebas en más dispositivos y evaluar ajustes de sensibilidad. Podría estudiarse un sistema de controles virtuales para mayor accesibilidad.
+
+###SHA
+<<git SHA>>

--- a/game.js
+++ b/game.js
@@ -49,29 +49,46 @@ async function start() {
   let lastX = 0;
   let lastY = 0;
 
-  canvas.addEventListener('pointerdown', (e) => {
+  function startDrag(x, y) {
     dragging = true;
-    lastX = e.clientX;
-    lastY = e.clientY;
-    canvas.setPointerCapture(e.pointerId);
-  });
+    lastX = x;
+    lastY = y;
+  }
 
-  canvas.addEventListener('pointermove', (e) => {
+  function moveDrag(x, y) {
     if (!dragging) return;
-    const dx = e.clientX - lastX;
-    const dy = e.clientY - lastY;
-    lastX = e.clientX;
-    lastY = e.clientY;
+    const dx = x - lastX;
+    const dy = y - lastY;
+    lastX = x;
+    lastY = y;
     player.x = Math.max(0, Math.min(canvas.width - player.size, player.x + dx));
     player.y = Math.max(0, Math.min(canvas.height - player.size, player.y + dy));
-  });
+  }
 
   function endDrag() {
     dragging = false;
   }
 
-  canvas.addEventListener('pointerup', endDrag);
-  canvas.addEventListener('pointercancel', endDrag);
+  if (window.PointerEvent) {
+    canvas.addEventListener('pointerdown', (e) => {
+      startDrag(e.clientX, e.clientY);
+      canvas.setPointerCapture(e.pointerId);
+    });
+    canvas.addEventListener('pointermove', (e) => moveDrag(e.clientX, e.clientY));
+    canvas.addEventListener('pointerup', endDrag);
+    canvas.addEventListener('pointercancel', endDrag);
+  } else {
+    canvas.addEventListener('touchstart', (e) => {
+      const t = e.touches[0];
+      startDrag(t.clientX, t.clientY);
+    }, { passive: false });
+    canvas.addEventListener('touchmove', (e) => {
+      const t = e.touches[0];
+      moveDrag(t.clientX, t.clientY);
+    }, { passive: false });
+    canvas.addEventListener('touchend', endDrag);
+    canvas.addEventListener('touchcancel', endDrag);
+  }
 
   function draw() {
     if (wasmModule) {


### PR DESCRIPTION
## Summary
- add touch event fallback in `game.js`
- record decision about improving touch controls

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6862dc7141d483319be1f33518423a71