### PR TITLE
Add touch plant collection

### DIFF
--- a/decisiones/20250715-plantas-tactiles.md
+++ b/decisiones/20250715-plantas-tactiles.md
@@ -1,0 +1,17 @@
+# Recoleccion tactil de plantas
+
+## Resumen
+Se añade una meta etiqueta `viewport` para mejorar el control en móviles y se implementa la interacción directa con las plantas. Al tocar un círculo este desaparece y el contador aumenta.
+
+## Razonamiento
+Sin la etiqueta `viewport` las coordenadas táctiles no coincidían con el lienzo y era difícil mover al personaje. Además se buscó una forma sencilla de recolectar plantas en dispositivos táctiles tocándolas directamente.
+
+## Alternativas consideradas
+- Mantener solo la recolección por colisión con el jugador: menos intuitivo en pantallas táctiles.
+- Usar solo JavaScript sin actualizar el módulo Rust: duplicaría la lógica del juego.
+
+## Sugerencias
+Se podría animar la desaparición de la planta y generar posiciones aleatorias para mayor rejugabilidad.
+
+###SHA
+<git SHA>

--- a/game.html
+++ b/game.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Achtli Game Prototype</title>
   <link rel="stylesheet" href="style.css">
   <script type="module" src="game.js"></script>

--- a/wasm_game/src/lib.rs
+++ b/wasm_game/src/lib.rs
@@ -75,6 +75,24 @@ impl Game {
         }
     }
 
+    pub fn collect_at(&mut self, x: f64, y: f64) -> bool {
+        let mut i = 0;
+        let mut collected = false;
+        while i < self.plants.len() {
+            let (px, py) = self.plants[i];
+            let dx = x - px;
+            let dy = y - py;
+            if (dx * dx + dy * dy).sqrt() < 20.0 {
+                self.plants.remove(i);
+                self.collected += 1;
+                collected = true;
+            } else {
+                i += 1;
+            }
+        }
+        collected
+    }
+
     pub fn player_x(&self) -> f64 { self.player_x }
     pub fn player_y(&self) -> f64 { self.player_y }
     pub fn plant_count(&self) -> usize { self.plants.len() }


### PR DESCRIPTION
## Summary
- allow tapping plants to collect them
- add JS fallback plant logic
- expose `collect_at` in WASM
- include viewport meta for mobile movement
- record decision

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6862fab7d29c8331b9575c742f938a4c