### PR TITLE
Update README about existing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Asegúrate de tener las herramientas básicas para compilar el módulo WebAssemb
 Si la compilación no está disponible, el juego utiliza automáticamente una versión en JavaScript como respaldo.
 
 ## Pruebas automáticas
-Próximamente se añadirá una suite de pruebas para validar el código. Una vez que exista podrás ejecutarla con:
+El repositorio ya cuenta con pruebas en **Rust** y **JavaScript**. Puedes ejecutarlas con:
 ```bash
-cargo test       # para las pruebas de Rust
-npm test         # para las pruebas de JavaScript
+cargo test       # pruebas de Rust
+npm test         # pruebas de JS y wasm (requiere wasm-pack)
 ```
-Las pruebas automatizadas ejecutan pequeños programas que verifican que cada parte del proyecto funcione como se espera. Esto ayuda a detectar errores antes de publicar los cambios y se ejecutará de forma automática en GitHub Actions cuando envíes código al repositorio.
+Asegúrate de que `wasm-pack` esté instalado y disponible en tu `PATH`, ya que `npm test` lo utiliza para compilar y ejecutar la biblioteca WebAssembly. Las pruebas automatizadas verifican que cada parte del proyecto funcione como se espera y se ejecutarán también en GitHub Actions cuando envíes código al repositorio.
 
 Si la compilación no está disponible, el juego utiliza una versión en JavaScript puro como respaldo.
 

--- a/decisiones/20250717-readme-tests.md
+++ b/decisiones/20250717-readme-tests.md
@@ -1,0 +1,14 @@
+# Actualizar README sobre pruebas
+
+## Resumen
+Se ajustó la sección de *Pruebas automáticas* en `README.md` para indicar que ya existen tests en Rust y JavaScript. También se aclaró que `npm test` necesita `wasm-pack`.
+
+## Razonamiento
+La documentación seguía mencionando que las pruebas se agregarían en el futuro, lo cual ya no es cierto. Explicar la dependencia de `wasm-pack` evita confusiones al ejecutar `npm test`.
+
+## Alternativas consideradas
+- Mantener el mensaje anterior que hablaba de pruebas futuras.
+- Describir por separado la instalación de Jest.
+
+## Sugerencias
+Ampliar las pruebas para cubrir más mecánicas del juego y aprovechar la automatización en CI.


### PR DESCRIPTION
## Summary
- update README to say Rust and JavaScript tests already exist
- highlight that npm test requires wasm-pack
- describe changes in decisions file

## Testing
- `npm test`
- `cargo test --manifest-path wasm_game/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6863159ab228833180fefa3d6b3a25f5