### PR TITLE
Add plant growth module

### DIFF
--- a/__tests__/game_logic.test.js
+++ b/__tests__/game_logic.test.js
@@ -1,14 +1,14 @@
 const { jsCollectAt } = require('../game_logic');
 
 test('collects a plant when coordinates match', () => {
-  const plants = [{ x: 10, y: 10 }];
+  const plants = [{ species: 'fast', stage: 0, timer: 0, x: 10, y: 10 }];
   const hit = jsCollectAt(plants, 10, 10);
   expect(hit).toBe(true);
   expect(plants.length).toBe(0);
 });
 
 test('returns false when no plant is nearby', () => {
-  const plants = [{ x: 10, y: 10 }];
+  const plants = [{ species: 'fast', stage: 0, timer: 0, x: 10, y: 10 }];
   const hit = jsCollectAt(plants, 100, 100);
   expect(hit).toBe(false);
   expect(plants.length).toBe(1);

--- a/decisiones/20250717-crecer-plantas.md
+++ b/decisiones/20250717-crecer-plantas.md
@@ -1,0 +1,14 @@
+# Sistema de crecimiento de plantas
+
+## Resumen
+Se añadieron estructuras y lógica para que cada planta avance de etapa con intervalos según su especie. El juego actualiza todas las plantas en cada cuadro tanto en Rust como en la versión de respaldo en JavaScript.
+
+## Razonamiento
+El prototipo necesitaba representar el ciclo de vida de distintas especies. Con una estructura dedicada y un módulo de crecimiento es posible simular tiempos realistas sin complicar el resto del código.
+
+## Alternativas consideradas
+- Mantener solo posiciones fijas sin etapas.
+- Calcular el crecimiento directamente dentro de `Game` sin separar módulos.
+
+## Sugerencias
+Agregar más especies y efectos visuales para cada etapa de crecimiento.

--- a/game.js
+++ b/game.js
@@ -25,9 +25,9 @@ async function start() {
   } catch (e) {
     console.warn('WASM failed, drawing pink with JS', e);
     jsPlants = [
-      { x: 50, y: 50 },
-      { x: 150, y: 80 },
-      { x: 80, y: 150 }
+      { species: 'fast', stage: 0, timer: 0, x: 50, y: 50 },
+      { species: 'medium', stage: 0, timer: 0, x: 150, y: 80 },
+      { species: 'slow', stage: 0, timer: 0, x: 80, y: 150 }
     ];
   }
 
@@ -36,6 +36,7 @@ async function start() {
   const speed = 5;
   const counter = document.getElementById('counter');
   let lastCollected = 0;
+  let lastTime = performance.now();
 
   function jsCollectAt(x, y) {
     if (!jsPlants) return false;
@@ -58,6 +59,33 @@ async function start() {
 
   function jsCheckCollisions() {
     jsCollectAt(player.x + playerSize / 2, player.y + playerSize / 2);
+  }
+
+  function intervalForSpecies(species) {
+    switch (species) {
+      case 'fast':
+        return 1;
+      case 'medium':
+        return 60;
+      case 'slow':
+        return 3600;
+      default:
+        return 10;
+    }
+  }
+
+  function jsUpdatePlant(p, dt) {
+    p.timer += dt;
+    const interval = intervalForSpecies(p.species);
+    while (p.timer >= interval) {
+      p.timer -= interval;
+      p.stage++;
+    }
+  }
+
+  function jsUpdate(dt) {
+    if (!jsPlants) return;
+    jsPlants.forEach(p => jsUpdatePlant(p, dt));
   }
 
   canvas.focus();
@@ -150,6 +178,14 @@ async function start() {
   }
 
   function draw() {
+    const now = performance.now();
+    const dt = (now - lastTime) / 1000;
+    lastTime = now;
+    if (game) {
+      game.update(dt);
+    } else {
+      jsUpdate(dt);
+    }
     if (wasmModule) {
       wasmModule.draw_pink();
     } else {

--- a/wasm_game/src/growth.rs
+++ b/wasm_game/src/growth.rs
@@ -1,0 +1,19 @@
+use crate::plant::Plant;
+
+pub fn interval_for_species(species: &str) -> f64 {
+    match species {
+        "fast" => 1.0,    // seconds
+        "medium" => 60.0, // minutes
+        "slow" => 3600.0, // hours
+        _ => 10.0,
+    }
+}
+
+pub fn update(plant: &mut Plant, dt: f64) {
+    plant.timer += dt;
+    let interval = interval_for_species(&plant.species);
+    while plant.timer >= interval {
+        plant.timer -= interval;
+        plant.stage += 1;
+    }
+}

--- a/wasm_game/src/lib.rs
+++ b/wasm_game/src/lib.rs
@@ -1,8 +1,12 @@
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsValue;
 use js_sys::Array;
+use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, window};
+use wasm_bindgen::JsValue;
+use web_sys::{window, CanvasRenderingContext2d, HtmlCanvasElement};
+
+mod growth;
+mod plant;
+use plant::Plant;
 
 #[wasm_bindgen]
 pub fn draw_pink() -> Result<(), JsValue> {
@@ -31,7 +35,7 @@ pub struct Game {
     height: f64,
     player_x: f64,
     player_y: f64,
-    plants: Vec<(f64, f64)>,
+    plants: Vec<Plant>,
     collected: u32,
 }
 
@@ -40,9 +44,9 @@ impl Game {
     #[wasm_bindgen(constructor)]
     pub fn new(width: f64, height: f64) -> Game {
         let plants = vec![
-            (50.0, 50.0),
-            (150.0, 80.0),
-            (80.0, 150.0),
+            Plant::new("fast", 50.0, 50.0),
+            Plant::new("medium", 150.0, 80.0),
+            Plant::new("slow", 80.0, 150.0),
         ];
         Game {
             width,
@@ -51,6 +55,12 @@ impl Game {
             player_y: height / 2.0,
             plants,
             collected: 0,
+        }
+    }
+
+    pub fn update(&mut self, dt: f64) {
+        for plant in &mut self.plants {
+            growth::update(plant, dt);
         }
     }
 
@@ -63,7 +73,8 @@ impl Game {
     fn check_collisions(&mut self) {
         let mut i = 0;
         while i < self.plants.len() {
-            let (px, py) = self.plants[i];
+            let px = self.plants[i].x;
+            let py = self.plants[i].y;
             let dx = self.player_x - px;
             let dy = self.player_y - py;
             if (dx * dx + dy * dy).sqrt() < 20.0 {
@@ -79,7 +90,8 @@ impl Game {
         let mut i = 0;
         let mut collected = false;
         while i < self.plants.len() {
-            let (px, py) = self.plants[i];
+            let px = self.plants[i].x;
+            let py = self.plants[i].y;
             let dx = x - px;
             let dy = y - py;
             if (dx * dx + dy * dy).sqrt() < 20.0 {
@@ -93,19 +105,31 @@ impl Game {
         collected
     }
 
-    pub fn player_x(&self) -> f64 { self.player_x }
-    pub fn player_y(&self) -> f64 { self.player_y }
-    pub fn plant_count(&self) -> usize { self.plants.len() }
-    pub fn plant_x(&self, idx: usize) -> f64 { self.plants[idx].0 }
-    pub fn plant_y(&self, idx: usize) -> f64 { self.plants[idx].1 }
-    pub fn collected(&self) -> u32 { self.collected }
+    pub fn player_x(&self) -> f64 {
+        self.player_x
+    }
+    pub fn player_y(&self) -> f64 {
+        self.player_y
+    }
+    pub fn plant_count(&self) -> usize {
+        self.plants.len()
+    }
+    pub fn plant_x(&self, idx: usize) -> f64 {
+        self.plants[idx].x
+    }
+    pub fn plant_y(&self, idx: usize) -> f64 {
+        self.plants[idx].y
+    }
+    pub fn collected(&self) -> u32 {
+        self.collected
+    }
 
     pub fn plant_positions(&self) -> Array {
         let arr = Array::new();
-        for (x, y) in &self.plants {
+        for plant in &self.plants {
             let pair = Array::new();
-            pair.push(&JsValue::from_f64(*x));
-            pair.push(&JsValue::from_f64(*y));
+            pair.push(&JsValue::from_f64(plant.x));
+            pair.push(&JsValue::from_f64(plant.y));
             arr.push(&pair);
         }
         arr
@@ -116,7 +140,6 @@ impl Game {
 mod tests {
     use super::*;
     use wasm_bindgen_test::*;
-
 
     #[wasm_bindgen_test]
     fn move_player_bounds() {

--- a/wasm_game/src/plant.rs
+++ b/wasm_game/src/plant.rs
@@ -1,0 +1,19 @@
+pub struct Plant {
+    pub species: String,
+    pub stage: u32,
+    pub timer: f64,
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Plant {
+    pub fn new(species: &str, x: f64, y: f64) -> Self {
+        Self {
+            species: species.to_string(),
+            stage: 0,
+            timer: 0.0,
+            x,
+            y,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `Plant` struct for species and growth tracking
- add `growth` module to advance plant stages over time
- update `Game` to manage a list of `Plant` instances and tick them each frame
- extend JS fallback with equivalent growth logic
- document the change in `decisiones/20250717-crecer-plantas.md`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686315b180748331b0725cc1444d10d9