### PR TITLE
Add maturity-aware harvesting

### DIFF
--- a/__tests__/game_logic.test.js
+++ b/__tests__/game_logic.test.js
@@ -1,15 +1,22 @@
 const { jsCollectAt } = require('../game_logic');
 
-test('collects a plant when coordinates match', () => {
-  const plants = [{ x: 10, y: 10 }];
+test('collects a mature plant when coordinates match', () => {
+  const plants = [{ x: 10, y: 10, mature: true }];
   const hit = jsCollectAt(plants, 10, 10);
   expect(hit).toBe(true);
   expect(plants.length).toBe(0);
 });
 
 test('returns false when no plant is nearby', () => {
-  const plants = [{ x: 10, y: 10 }];
+  const plants = [{ x: 10, y: 10, mature: true }];
   const hit = jsCollectAt(plants, 100, 100);
+  expect(hit).toBe(false);
+  expect(plants.length).toBe(1);
+});
+
+test('does not collect immature plant', () => {
+  const plants = [{ x: 10, y: 10, mature: false }];
+  const hit = jsCollectAt(plants, 10, 10);
   expect(hit).toBe(false);
   expect(plants.length).toBe(1);
 });

--- a/decisiones/20250717-cosecha-madura.md
+++ b/decisiones/20250717-cosecha-madura.md
@@ -1,0 +1,14 @@
+# Plantas maduras
+
+## Resumen
+Se actualiza la lógica de colisiones para que solo se puedan recolectar las plantas maduras. También se modifican los colores y tamaños para distinguir las cosechables.
+
+## Razonamiento
+Los jugadores necesitan saber cuándo una planta está lista para recolectarse. La mecánica evita eliminarlas por accidente y agrega feedback visual.
+
+## Alternativas consideradas
+- Usar animaciones en lugar de cambiar el color.
+- Mostrar un icono flotante sobre las plantas maduras.
+
+## Sugerencias
+Futuras versiones podrían incluir un sistema de crecimiento en tiempo real que vaya cambiando el estado de cada planta.

--- a/game.js
+++ b/game.js
@@ -25,9 +25,9 @@ async function start() {
   } catch (e) {
     console.warn('WASM failed, drawing pink with JS', e);
     jsPlants = [
-      { x: 50, y: 50 },
-      { x: 150, y: 80 },
-      { x: 80, y: 150 }
+      { x: 50, y: 50, mature: true },
+      { x: 150, y: 80, mature: false },
+      { x: 80, y: 150, mature: true }
     ];
   }
 
@@ -45,7 +45,7 @@ async function start() {
       const p = jsPlants[i];
       const dx = x - p.x;
       const dy = y - p.y;
-      if (Math.sqrt(dx * dx + dy * dy) < 20) {
+      if (p.mature && Math.sqrt(dx * dx + dy * dy) < 20) {
         jsPlants.splice(i, 1);
         jsCollected++;
         hit = true;
@@ -57,7 +57,21 @@ async function start() {
   }
 
   function jsCheckCollisions() {
-    jsCollectAt(player.x + playerSize / 2, player.y + playerSize / 2);
+    if (!jsPlants) return;
+    let i = 0;
+    const cx = player.x + playerSize / 2;
+    const cy = player.y + playerSize / 2;
+    while (i < jsPlants.length) {
+      const p = jsPlants[i];
+      const dx = cx - p.x;
+      const dy = cy - p.y;
+      if (p.mature && Math.sqrt(dx * dx + dy * dy) < 20) {
+        jsPlants.splice(i, 1);
+        jsCollected++;
+      } else {
+        i++;
+      }
+    }
   }
 
   canvas.focus();
@@ -159,11 +173,11 @@ async function start() {
 
     if (game) {
       const positions = game.plant_positions();
-      ctx.fillStyle = 'green';
       for (let i = 0; i < positions.length; i++) {
-        const [x, y] = positions[i];
+        const [x, y, mature] = positions[i];
+        ctx.fillStyle = mature ? 'green' : 'lightgreen';
         ctx.beginPath();
-        ctx.arc(x, y, 10, 0, Math.PI * 2);
+        ctx.arc(x, y, mature ? 12 : 10, 0, Math.PI * 2);
         ctx.fill();
       }
       const collected = game.collected();
@@ -175,11 +189,11 @@ async function start() {
       ctx.fillRect(game.player_x(), game.player_y(), playerSize, playerSize);
     } else {
       if (jsPlants) {
-        ctx.fillStyle = 'green';
         for (let i = 0; i < jsPlants.length; i++) {
           const p = jsPlants[i];
+          ctx.fillStyle = p.mature ? 'green' : 'lightgreen';
           ctx.beginPath();
-          ctx.arc(p.x, p.y, 10, 0, Math.PI * 2);
+          ctx.arc(p.x, p.y, p.mature ? 12 : 10, 0, Math.PI * 2);
           ctx.fill();
         }
       }

--- a/game_logic.js
+++ b/game_logic.js
@@ -5,7 +5,7 @@ function jsCollectAt(plants, x, y) {
     const p = plants[i];
     const dx = x - p.x;
     const dy = y - p.y;
-    if (Math.sqrt(dx * dx + dy * dy) < 20) {
+    if (p.mature && Math.sqrt(dx * dx + dy * dy) < 20) {
       plants.splice(i, 1);
       hit = true;
     } else {

--- a/wasm_game/src/lib.rs
+++ b/wasm_game/src/lib.rs
@@ -26,12 +26,20 @@ pub fn draw_pink() -> Result<(), JsValue> {
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen]
+#[derive(Clone)]
+struct Plant {
+    x: f64,
+    y: f64,
+    mature: bool,
+}
+
+#[wasm_bindgen]
 pub struct Game {
     width: f64,
     height: f64,
     player_x: f64,
     player_y: f64,
-    plants: Vec<(f64, f64)>,
+    plants: Vec<Plant>,
     collected: u32,
 }
 
@@ -40,9 +48,9 @@ impl Game {
     #[wasm_bindgen(constructor)]
     pub fn new(width: f64, height: f64) -> Game {
         let plants = vec![
-            (50.0, 50.0),
-            (150.0, 80.0),
-            (80.0, 150.0),
+            Plant { x: 50.0, y: 50.0, mature: true },
+            Plant { x: 150.0, y: 80.0, mature: false },
+            Plant { x: 80.0, y: 150.0, mature: true },
         ];
         Game {
             width,
@@ -63,10 +71,10 @@ impl Game {
     fn check_collisions(&mut self) {
         let mut i = 0;
         while i < self.plants.len() {
-            let (px, py) = self.plants[i];
-            let dx = self.player_x - px;
-            let dy = self.player_y - py;
-            if (dx * dx + dy * dy).sqrt() < 20.0 {
+            let plant = &self.plants[i];
+            let dx = self.player_x - plant.x;
+            let dy = self.player_y - plant.y;
+            if plant.mature && (dx * dx + dy * dy).sqrt() < 20.0 {
                 self.plants.remove(i);
                 self.collected += 1;
             } else {
@@ -79,10 +87,10 @@ impl Game {
         let mut i = 0;
         let mut collected = false;
         while i < self.plants.len() {
-            let (px, py) = self.plants[i];
-            let dx = x - px;
-            let dy = y - py;
-            if (dx * dx + dy * dy).sqrt() < 20.0 {
+            let plant = &self.plants[i];
+            let dx = x - plant.x;
+            let dy = y - plant.y;
+            if plant.mature && (dx * dx + dy * dy).sqrt() < 20.0 {
                 self.plants.remove(i);
                 self.collected += 1;
                 collected = true;
@@ -96,16 +104,18 @@ impl Game {
     pub fn player_x(&self) -> f64 { self.player_x }
     pub fn player_y(&self) -> f64 { self.player_y }
     pub fn plant_count(&self) -> usize { self.plants.len() }
-    pub fn plant_x(&self, idx: usize) -> f64 { self.plants[idx].0 }
-    pub fn plant_y(&self, idx: usize) -> f64 { self.plants[idx].1 }
+    pub fn plant_x(&self, idx: usize) -> f64 { self.plants[idx].x }
+    pub fn plant_y(&self, idx: usize) -> f64 { self.plants[idx].y }
+    pub fn plant_mature(&self, idx: usize) -> bool { self.plants[idx].mature }
     pub fn collected(&self) -> u32 { self.collected }
 
     pub fn plant_positions(&self) -> Array {
         let arr = Array::new();
-        for (x, y) in &self.plants {
+        for plant in &self.plants {
             let pair = Array::new();
-            pair.push(&JsValue::from_f64(*x));
-            pair.push(&JsValue::from_f64(*y));
+            pair.push(&JsValue::from_f64(plant.x));
+            pair.push(&JsValue::from_f64(plant.y));
+            pair.push(&JsValue::from_bool(plant.mature));
             arr.push(&pair);
         }
         arr
@@ -135,5 +145,16 @@ mod tests {
         assert!(game.collect_at(x, y));
         assert_eq!(game.plant_count(), initial - 1);
         assert_eq!(game.collected(), 1);
+    }
+
+    #[wasm_bindgen_test]
+    fn collect_at_ignores_immature() {
+        let mut game = Game::new(100.0, 100.0);
+        let x = game.plant_x(1);
+        let y = game.plant_y(1);
+        let initial = game.plant_count();
+        assert!(!game.collect_at(x, y));
+        assert_eq!(game.plant_count(), initial);
+        assert_eq!(game.collected(), 0);
     }
 }


### PR DESCRIPTION
## Summary
- mark plants with a `mature` flag both in JS and Rust
- only allow harvesting of mature plants in both runtimes
- show harvestable plants with darker green color and larger radius
- add tests for the new JS logic
- document decision

## Testing
- `npm test` *(fails: wasm-pack not found)*
- `npx jest` *(fails: needs package install)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686315f94aec8331bb678fb4e78110c5