### PR TITLE
Fix plant growth and overlay

### DIFF
--- a/__tests__/game_logic.test.js
+++ b/__tests__/game_logic.test.js
@@ -1,15 +1,22 @@
-const { jsCollectAt } = require('../game_logic');
+const { jsCollectAt, MATURE_STAGE } = require('../game_logic');
 
-test('collects a plant when coordinates match', () => {
-  const plants = [{ x: 10, y: 10 }];
+test('collects a mature plant when coordinates match', () => {
+  const plants = [{ x: 10, y: 10, stage: MATURE_STAGE }];
   const hit = jsCollectAt(plants, 10, 10);
   expect(hit).toBe(true);
   expect(plants.length).toBe(0);
 });
 
 test('returns false when no plant is nearby', () => {
-  const plants = [{ x: 10, y: 10 }];
+  const plants = [{ x: 10, y: 10, stage: MATURE_STAGE }];
   const hit = jsCollectAt(plants, 100, 100);
+  expect(hit).toBe(false);
+  expect(plants.length).toBe(1);
+});
+
+test('does not collect if plant is not mature', () => {
+  const plants = [{ x: 10, y: 10, stage: 2 }];
+  const hit = jsCollectAt(plants, 10, 10);
   expect(hit).toBe(false);
   expect(plants.length).toBe(1);
 });

--- a/decisiones/20250719-madurez-overlay-colision.md
+++ b/decisiones/20250719-madurez-overlay-colision.md
@@ -1,0 +1,14 @@
+# Correcciones de madurez y overlay
+
+## Resumen
+Se detuvo el crecimiento de las plantas al alcanzar su etapa final, se reactivó la superposición con detalles de la especie y la recolección ahora solo es posible con plantas maduras.
+
+## Razonamiento
+Los ciclos de crecimiento sin límite generaban valores inconsistentes y la superposición no aparecía por falta de datos y funciones de búsqueda. Además la colisión permitía recolectar brotes, rompiendo la mecánica esperada.
+
+## Alternativas consideradas
+- Mantener el contador de etapas infinito.
+- Mostrar la información en otra página.
+
+## Sugerencias
+Agregar más especies y fases para ampliar la base de datos y probar la nueva lógica con gráficos dedicados.

--- a/game.js
+++ b/game.js
@@ -17,6 +17,12 @@ const MATURE_STAGE = 5;
 async function start() {
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
+  const overlay = document.getElementById('plant-overlay');
+  const plantInfo = [
+    { name: 'Planta rápida', requirements: 'Riego frecuente', desc: 'Crecimiento veloz' },
+    { name: 'Planta media', requirements: 'Sol y agua moderados', desc: 'Crecimiento regular' },
+    { name: 'Planta lenta', requirements: 'Poca agua', desc: 'Crecimiento lento y resistente' }
+  ];
 
   function resize() {
     canvas.width = window.innerWidth;
@@ -45,9 +51,10 @@ async function start() {
   function jsUpdatePlants(dt) {
     if (!jsPlants) return;
     for (const plant of jsPlants) {
+      if (plant.stage >= MATURE_STAGE) continue;
       plant.timer += dt;
       const interval = jsGrowthInterval(plant.species);
-      while (plant.timer >= interval) {
+      while (plant.stage < MATURE_STAGE && plant.timer >= interval) {
         plant.timer -= interval;
         plant.stage += 1;
         if (plant.stage === 1) {
@@ -89,7 +96,7 @@ async function start() {
       const p = jsPlants[i];
       const dx = x - p.x;
       const dy = y - p.y;
-      if (Math.sqrt(dx * dx + dy * dy) < 20) {
+      if (Math.sqrt(dx * dx + dy * dy) < 20 && p.stage >= MATURE_STAGE) {
         jsPlants.splice(i, 1);
         jsCollected++;
         hit = true;
@@ -180,12 +187,13 @@ async function start() {
   }
 
   function showOverlay(index) {
-    const info = plantInfo[index];
-    if (!info) return;
-    overlay.innerHTML = `<h2>${info.name}</h2>` +
-      `<p>Fase actual: ${info.phase}</p>` +
-      `<p>Requisitos: ${info.requirements}</p>` +
-      `<p>${info.desc}</p>`;
+    const species = game ? game.plant_species(index) : (jsPlants ? jsPlants[index].species : '');
+    const stage = game ? game.plant_stage(index) : (jsPlants ? jsPlants[index].stage : 0);
+    const info = plantInfo[index] || {};
+    overlay.innerHTML = `<h2>${info.name || species}</h2>` +
+      `<p>Fase actual: ${stage}</p>` +
+      `<p>Requisitos: ${info.requirements || ''}</p>` +
+      `<p>${info.desc || ''}</p>`;
     overlay.style.display = 'block';
   }
 

--- a/game_logic.js
+++ b/game_logic.js
@@ -1,3 +1,5 @@
+const MATURE_STAGE = 5;
+
 function jsCollectAt(plants, x, y) {
   let i = 0;
   let hit = false;
@@ -5,7 +7,7 @@ function jsCollectAt(plants, x, y) {
     const p = plants[i];
     const dx = x - p.x;
     const dy = y - p.y;
-    if (Math.sqrt(dx * dx + dy * dy) < 20) {
+    if (Math.sqrt(dx * dx + dy * dy) < 20 && p.stage >= MATURE_STAGE) {
       plants.splice(i, 1);
       hit = true;
     } else {
@@ -27,4 +29,4 @@ function jsFindPlantAt(plants, x, y) {
   return -1;
 }
 
-module.exports = { jsCollectAt, jsFindPlantAt };
+module.exports = { jsCollectAt, jsFindPlantAt, MATURE_STAGE };

--- a/wasm_game/src/growth.rs
+++ b/wasm_game/src/growth.rs
@@ -9,7 +9,7 @@ pub fn interval_for_species(species: &str) -> f64 {
 use crate::Plant;
 use js_sys::Math;
 
-const MATURE_STAGE: u32 = 5;
+pub const MATURE_STAGE: u32 = 5;
 
 pub fn seed_color() -> String {
     if Math::random() < 0.5 {
@@ -26,9 +26,12 @@ fn mature_color() -> String {
 }
 
 pub fn update_plant(plant: &mut Plant, dt: f64) {
+    if plant.stage >= MATURE_STAGE {
+        return;
+    }
     plant.timer += dt;
     let interval = interval_for_species(&plant.species);
-    while plant.timer >= interval {
+    while plant.stage < MATURE_STAGE && plant.timer >= interval {
         plant.timer -= interval;
         plant.stage += 1;
         if plant.stage == 1 {

--- a/wasm_game/src/lib.rs
+++ b/wasm_game/src/lib.rs
@@ -98,7 +98,9 @@ impl Game {
             let py = self.plants[i].y;
             let dx = self.player_x - px;
             let dy = self.player_y - py;
-            if (dx * dx + dy * dy).sqrt() < 20.0 {
+            if (dx * dx + dy * dy).sqrt() < 20.0
+                && self.plants[i].stage >= growth::MATURE_STAGE
+            {
                 self.plants.remove(i);
                 self.collected += 1;
             } else {
@@ -115,7 +117,9 @@ impl Game {
             let py = self.plants[i].y;
             let dx = x - px;
             let dy = y - py;
-            if (dx * dx + dy * dy).sqrt() < 20.0 {
+            if (dx * dx + dy * dy).sqrt() < 20.0
+                && self.plants[i].stage >= growth::MATURE_STAGE
+            {
                 self.plants.remove(i);
                 self.collected += 1;
                 collected = true;
@@ -145,6 +149,9 @@ impl Game {
     pub fn plant_stage(&self, idx: usize) -> u32 {
         self.plants[idx].stage
     }
+    pub fn plant_species(&self, idx: usize) -> String {
+        self.plants[idx].species.clone()
+    }
     pub fn collected(&self) -> u32 {
         self.collected
     }
@@ -160,6 +167,17 @@ impl Game {
             arr.push(&quad);
         }
         arr
+    }
+
+    pub fn plant_index_at(&self, x: f64, y: f64) -> i32 {
+        for (i, plant) in self.plants.iter().enumerate() {
+            let dx = x - plant.x;
+            let dy = y - plant.y;
+            if (dx * dx + dy * dy).sqrt() < 20.0 {
+                return i as i32;
+            }
+        }
+        -1
     }
 }
 
@@ -181,6 +199,10 @@ mod tests {
         let mut game = Game::new(100.0, 100.0);
         let x = game.plant_x(0);
         let y = game.plant_y(0);
+        // advance plant to maturity
+        for _ in 0..growth::MATURE_STAGE {
+            growth::update_plant(&mut game.plants[0], growth::interval_for_species("fast"));
+        }
         let initial = game.plant_count();
         assert!(game.collect_at(x, y));
         assert_eq!(game.plant_count(), initial - 1);


### PR DESCRIPTION
## Summary
- stop plants from growing past maturity
- show species overlay when clicking on a plant
- collect plants only once they're mature
- update tests for new mature stage rules
- document the change

## Testing
- `npm test` *(fails: wasm-pack not found)*
- `cargo test` in `wasm_game`

------
https://chatgpt.com/codex/tasks/task_e_68633b10d718833189bc1db2c956727f