### PR TITLE
Refactor JS into modules

### DIFF
--- a/__tests__/game_logic.test.js
+++ b/__tests__/game_logic.test.js
@@ -1,4 +1,11 @@
-const { jsCollectAt, MATURE_STAGE } = require('../game_logic');
+let jsCollectAt;
+let MATURE_STAGE;
+
+beforeAll(async () => {
+  const mod = await import('../js/game-logic.js');
+  jsCollectAt = mod.jsCollectAt;
+  MATURE_STAGE = mod.MATURE_STAGE;
+});
 
 test('collects a mature plant when coordinates match', () => {
   const plants = [{ x: 10, y: 10, stage: MATURE_STAGE }];

--- a/decisiones/20250701-modular-js.md
+++ b/decisiones/20250701-modular-js.md
@@ -1,0 +1,14 @@
+# Reorganizar codigo JS
+
+## Resumen
+Se separo `game.js` en modulos dentro de la carpeta `js/` para mantener responsabilidades claras.
+
+## Razonamiento
+Dividir el codigo facilita el mantenimiento y permite importar un unico punto de entrada desde `game.html`.
+
+## Alternativas consideradas
+- Mantener todo en un solo archivo.
+- Usar un framework diferente para manejar modulos.
+
+## Sugerencias
+Revisar que el flujo de versionado automatico contemple ahora `js/main.js` si se desea seguir incrementando la version.

--- a/game.html
+++ b/game.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Achtli Game Prototype</title>
   <link rel="stylesheet" href="style.css">
-  <script type="module" src="game.js"></script>
+  <script type="module" src="js/main.js"></script>
   <style>
     body { margin: 0; }
     #counter {

--- a/js/game-logic.js
+++ b/js/game-logic.js
@@ -1,0 +1,79 @@
+export const MATURE_STAGE = 5;
+
+function randomChoice(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export function seedColor() {
+  return randomChoice(['brown', 'black']);
+}
+
+export function matureColor() {
+  return randomChoice(['red', 'white', 'blue', 'yellow']);
+}
+
+export function jsGrowthInterval(species) {
+  switch (species) {
+    case 'fast':
+      return 1;
+    case 'slow':
+      return 3600;
+    default:
+      return 60;
+  }
+}
+
+export function jsUpdatePlants(plants, dt) {
+  if (!plants) return;
+  for (const plant of plants) {
+    if (plant.stage >= MATURE_STAGE) continue;
+    plant.timer += dt;
+    const interval = jsGrowthInterval(plant.species);
+    while (plant.stage < MATURE_STAGE && plant.timer >= interval) {
+      plant.timer -= interval;
+      plant.stage += 1;
+      if (plant.stage === 1) {
+        plant.color = 'green';
+      } else if (plant.stage === MATURE_STAGE) {
+        plant.color = matureColor();
+      }
+    }
+  }
+}
+
+export function jsCollectAt(plants, x, y) {
+  let i = 0;
+  let hit = false;
+  while (i < plants.length) {
+    const p = plants[i];
+    const dx = x - p.x;
+    const dy = y - p.y;
+    if (Math.sqrt(dx * dx + dy * dy) < 20 && p.stage >= MATURE_STAGE) {
+      plants.splice(i, 1);
+      hit = true;
+    } else {
+      i++;
+    }
+  }
+  return hit;
+}
+
+export function jsFindPlantAt(plants, x, y) {
+  for (let i = 0; i < plants.length; i++) {
+    const p = plants[i];
+    const dx = x - p.x;
+    const dy = y - p.y;
+    if (Math.sqrt(dx * dx + dy * dy) < 20) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+export function createInitialPlants() {
+  return [
+    { x: 50, y: 50, species: 'fast', stage: 0, timer: 0, color: seedColor() },
+    { x: 150, y: 80, species: 'medium', stage: 0, timer: 0, color: seedColor() },
+    { x: 80, y: 150, species: 'slow', stage: 0, timer: 0, color: seedColor() }
+  ];
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,139 @@
+import { jsUpdatePlants, jsCollectAt, jsFindPlantAt, createInitialPlants } from './game-logic.js';
+import { setupUI } from './ui.js';
+
+const VERSION = '0.0.0.0';
+async function start() {
+  const canvas = document.getElementById('game');
+  const ctx = canvas.getContext('2d');
+  const overlay = document.getElementById('plant-overlay');
+
+  const plantInfo = [
+    { name: 'Planta rápida', requirements: 'Riego frecuente', desc: 'Crecimiento veloz' },
+    { name: 'Planta media', requirements: 'Sol y agua moderados', desc: 'Crecimiento regular' },
+    { name: 'Planta lenta', requirements: 'Poca agua', desc: 'Crecimiento lento y resistente' }
+  ];
+
+  function resize() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+
+  resize();
+  window.addEventListener('resize', resize);
+
+  let wasmModule = null;
+  let game = null;
+  let jsPlants = null;
+  let jsCollected = 0;
+
+  try {
+    const wasm = await import('../wasm_game/pkg/wasm_game.js');
+    await wasm.default();
+    wasm.draw_pink();
+    wasmModule = wasm;
+    game = new wasm.Game(canvas.width, canvas.height);
+  } catch (e) {
+    console.warn('WASM failed, drawing pink with JS', e);
+    jsPlants = createInitialPlants();
+  }
+
+  const playerSize = 20;
+  const player = { x: canvas.width / 2 - playerSize / 2, y: canvas.height / 2 - playerSize / 2 };
+  const counter = document.getElementById('counter');
+  let lastCollected = 0;
+  let lastTime = performance.now();
+
+  function jsCheckCollisions() {
+    if (jsCollectAt(jsPlants, player.x + playerSize / 2, player.y + playerSize / 2)) {
+      jsCollected++;
+    }
+  }
+
+  function movePlayer(dx, dy) {
+    if (game) {
+      game.move_player(dx, dy);
+    } else {
+      player.x = Math.max(0, Math.min(canvas.width - playerSize, player.x + dx));
+      player.y = Math.max(0, Math.min(canvas.height - playerSize, player.y + dy));
+      jsCheckCollisions();
+    }
+  }
+
+  function findPlantIndex(x, y) {
+    return game ? game.plant_index_at(x, y) : jsFindPlantAt(jsPlants, x, y);
+  }
+
+  function getPlantStage(index) {
+    return game ? game.plant_stage(index) : (jsPlants ? jsPlants[index].stage : 0);
+  }
+
+  function getPlantSpecies(index) {
+    return game ? game.plant_species(index) : (jsPlants ? jsPlants[index].species : '');
+  }
+
+  setupUI(canvas, overlay, plantInfo, { movePlayer, findPlantIndex, getPlantStage, getPlantSpecies });
+
+  function draw() {
+    const now = performance.now();
+    const dt = (now - lastTime) / 1000;
+    lastTime = now;
+    if (game) {
+      game.update(dt);
+    } else {
+      jsUpdatePlants(jsPlants, dt);
+    }
+
+    if (wasmModule) {
+      wasmModule.draw_pink();
+    } else {
+      ctx.fillStyle = 'pink';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+
+    if (game) {
+      const positions = game.plant_positions();
+      for (let i = 0; i < positions.length; i++) {
+        const [x, y, stage, color] = positions[i];
+        ctx.fillStyle = color;
+        ctx.beginPath();
+        ctx.arc(x, y, 5 + stage, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      const collected = game.collected();
+      if (collected !== lastCollected) {
+        counter.textContent = collected;
+        lastCollected = collected;
+      }
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(game.player_x(), game.player_y(), playerSize, playerSize);
+    } else {
+      if (jsPlants) {
+        for (let i = 0; i < jsPlants.length; i++) {
+          const p = jsPlants[i];
+          ctx.fillStyle = p.color;
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, 5 + p.stage, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+      if (jsCollected !== lastCollected) {
+        counter.textContent = jsCollected;
+        lastCollected = jsCollected;
+      }
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(player.x, player.y, playerSize, playerSize);
+    }
+
+    ctx.font = '16px sans-serif';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    ctx.fillStyle = 'white';
+    ctx.fillText(`version ${VERSION}`, canvas.width - 10, 10);
+
+    requestAnimationFrame(draw);
+  }
+
+  draw();
+}
+
+start();

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,108 @@
+export function setupUI(canvas, overlay, plantInfo, actions) {
+  const { movePlayer, findPlantIndex, getPlantStage, getPlantSpecies } = actions;
+  const speed = 5;
+
+  let dragging = false;
+  let lastX = 0;
+  let lastY = 0;
+
+  function startDrag(x, y) {
+    dragging = true;
+    lastX = x;
+    lastY = y;
+  }
+
+  function moveDrag(x, y) {
+    if (!dragging) return;
+    const dx = x - lastX;
+    const dy = y - lastY;
+    lastX = x;
+    lastY = y;
+    movePlayer(dx, dy);
+  }
+
+  function endDrag() {
+    dragging = false;
+  }
+
+  function showOverlay(index) {
+    const species = getPlantSpecies(index);
+    const stage = getPlantStage(index);
+    const info = plantInfo[index] || {};
+    overlay.innerHTML = `<h2>${info.name || species}</h2>` +
+      `<p>Fase actual: ${stage}</p>` +
+      `<p>Requisitos: ${info.requirements || ''}</p>` +
+      `<p>${info.desc || ''}</p>`;
+    overlay.style.display = 'block';
+  }
+
+  function hideOverlay() {
+    overlay.style.display = 'none';
+  }
+
+  canvas.focus();
+  canvas.addEventListener('keydown', (e) => {
+    let dx = 0;
+    let dy = 0;
+    switch (e.key) {
+      case 'ArrowUp':
+        e.preventDefault();
+        dy = -speed;
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        dy = speed;
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        dx = -speed;
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        dx = speed;
+        break;
+      default:
+        return;
+    }
+    movePlayer(dx, dy);
+  });
+
+  if (window.PointerEvent) {
+    canvas.addEventListener('pointerdown', (e) => {
+      const idx = findPlantIndex(e.clientX, e.clientY);
+      if (idx >= 0) {
+        e.stopPropagation();
+        showOverlay(idx);
+      } else {
+        startDrag(e.clientX, e.clientY);
+        canvas.setPointerCapture(e.pointerId);
+      }
+    });
+    canvas.addEventListener('pointermove', (e) => moveDrag(e.clientX, e.clientY));
+    canvas.addEventListener('pointerup', endDrag);
+    canvas.addEventListener('pointercancel', endDrag);
+  } else {
+    canvas.addEventListener('touchstart', (e) => {
+      const t = e.touches[0];
+      const idx = findPlantIndex(t.clientX, t.clientY);
+      if (idx >= 0) {
+        e.stopPropagation();
+        showOverlay(idx);
+      } else {
+        startDrag(t.clientX, t.clientY);
+      }
+    }, { passive: false });
+    canvas.addEventListener('touchmove', (e) => {
+      const t = e.touches[0];
+      moveDrag(t.clientX, t.clientY);
+    }, { passive: false });
+    canvas.addEventListener('touchend', endDrag);
+    canvas.addEventListener('touchcancel', endDrag);
+  }
+
+  document.addEventListener('pointerdown', (e) => {
+    if (overlay.style.display === 'block' && !overlay.contains(e.target)) {
+      hideOverlay();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- split `game.js` into `js/` modules
- load new entry point in `game.html`
- adapt unit tests to new path
- document decision

## Testing
- `npm test` *(fails: `wasm-pack` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863400b977083318c65f7e30a259881