### PR TITLE
Enable collapsible code blocks in docs

### DIFF
--- a/decisiones/20250701-material-details.md
+++ b/decisiones/20250701-material-details.md
@@ -1,0 +1,14 @@
+# Material details
+
+## Resumen
+Se configura MkDocs con el tema Material y se habilita la extensión `pymdownx.details`. Se documentan las funciones usando bloques `<details>` que permiten expandir y contraer cada fragmento de código.
+
+## Razonamiento
+El tema Material ofrece un aspecto moderno y funcional. Al usar la extensión `details` se facilita la lectura de la referencia de funciones sin saturar la página.
+
+## Alternativas consideradas
+- Mantener la configuración anterior de MkDocs.
+- Usar otros temas o extensiones.
+
+## Sugerencias
+Probar la documentación localmente con `mkdocs serve` para verificar la visualización y seguir ampliando la guía de código.

--- a/docs/funciones.md
+++ b/docs/funciones.md
@@ -5,25 +5,211 @@ Esta página describe brevemente las funciones disponibles en el proyecto.
 ## JavaScript
 
 ### js/game-logic.js
-- `seedColor()` y `matureColor()` generan colores aleatorios para las plantas.
-- `jsGrowthInterval(species)` define el tiempo de crecimiento según la especie.
-- `jsUpdatePlants(plants, dt)` actualiza el avance de todas las plantas.
-- `jsCollectAt(plants, x, y)` intenta recolectar una planta madura cercana.
-- `jsFindPlantAt(plants, x, y)` devuelve el índice de una planta en las coordenadas.
-- `createInitialPlants()` crea el conjunto inicial de plantas para el modo JS.
+<details><summary>`seedColor()`</summary>
+
+```javascript
+export function seedColor() {
+  return randomChoice(['brown', 'black']);
+}
+```
+
+</details>
+
+<details><summary>`matureColor()`</summary>
+
+```javascript
+export function matureColor() {
+  return randomChoice(['red', 'white', 'blue', 'yellow']);
+}
+```
+
+</details>
+
+<details><summary>`jsGrowthInterval(species)`</summary>
+
+```javascript
+export function jsGrowthInterval(species) {
+  switch (species) {
+    case 'fast':
+      return 1;
+    case 'slow':
+      return 3600;
+    default:
+      return 60;
+  }
+}
+```
+
+</details>
+
+<details><summary>`jsUpdatePlants(plants, dt)`</summary>
+
+```javascript
+export function jsUpdatePlants(plants, dt) {
+  if (!plants) return;
+  for (const plant of plants) {
+    if (plant.stage >= MATURE_STAGE) continue;
+    plant.timer += dt;
+    const interval = jsGrowthInterval(plant.species);
+    while (plant.stage < MATURE_STAGE && plant.timer >= interval) {
+      plant.timer -= interval;
+      plant.stage += 1;
+      if (plant.stage === 1) {
+        plant.color = 'green';
+      } else if (plant.stage === MATURE_STAGE) {
+        plant.color = matureColor();
+      }
+    }
+  }
+}
+```
+
+</details>
+
+<details><summary>`jsCollectAt(plants, x, y)`</summary>
+
+```javascript
+export function jsCollectAt(plants, x, y) {
+  let i = 0;
+  let hit = false;
+  while (i < plants.length) {
+    const p = plants[i];
+    const dx = x - p.x;
+    const dy = y - p.y;
+    if (Math.sqrt(dx * dx + dy * dy) < 20 && p.stage >= MATURE_STAGE) {
+      plants.splice(i, 1);
+      hit = true;
+    } else {
+      i++;
+    }
+  }
+  return hit;
+}
+```
+
+</details>
+
+<details><summary>`jsFindPlantAt(plants, x, y)`</summary>
+
+```javascript
+export function jsFindPlantAt(plants, x, y) {
+  for (let i = 0; i < plants.length; i++) {
+    const p = plants[i];
+    const dx = x - p.x;
+    const dy = y - p.y;
+    if (Math.sqrt(dx * dx + dy * dy) < 20) {
+      return i;
+    }
+  }
+  return -1;
+}
+```
+
+</details>
+
+<details><summary>`createInitialPlants()`</summary>
+
+```javascript
+export function createInitialPlants() {
+  return [
+    { x: 50, y: 50, species: 'fast', stage: 0, timer: 0, color: seedColor() },
+    { x: 150, y: 80, species: 'medium', stage: 0, timer: 0, color: seedColor() },
+    { x: 80, y: 150, species: 'slow', stage: 0, timer: 0, color: seedColor() }
+  ];
+}
+```
+
+</details>
 
 ### js/ui.js
-- `setupUI(canvas, overlay, plantInfo, actions)` conecta los controles del
-  jugador y muestra información de cada planta.
+<details><summary>`setupUI(canvas, overlay, plantInfo, actions)`</summary>
+
+```javascript
+export function setupUI(canvas, overlay, plantInfo, actions) {
+  const { movePlayer, findPlantIndex, getPlantStage, getPlantSpecies } = actions;
+  const speed = 5;
+  // ...manejo de controles y overlay
+}
+```
+
+</details>
 
 ### js/main.js
-- `start()` es el punto de entrada; carga el módulo wasm y comienza el ciclo de
-  dibujo.
-- Funciones internas como `movePlayer()` o `draw()` gestionan la lógica de
-  movimiento, colisiones y renderizado.
+<details><summary>`start()`</summary>
+
+```javascript
+async function start() {
+  const canvas = document.getElementById('game');
+  // ...inicialización y bucle principal
+}
+```
+
+</details>
+
+<details><summary>`movePlayer(dx, dy)`</summary>
+
+```javascript
+function movePlayer(dx, dy) {
+  if (game) {
+    game.move_player(dx, dy);
+  } else {
+    player.x = Math.max(0, Math.min(canvas.width - playerSize, player.x + dx));
+    player.y = Math.max(0, Math.min(canvas.height - playerSize, player.y + dy));
+    jsCheckCollisions();
+  }
+}
+```
+
+</details>
+
+<details><summary>`draw()`</summary>
+
+```javascript
+function draw() {
+  const now = performance.now();
+  const dt = (now - lastTime) / 1000;
+  lastTime = now;
+  // ...actualización y renderizado
+  requestAnimationFrame(draw);
+}
+```
+
+</details>
 
 ## Rust (wasm_game)
-- `draw_pink()` pinta el fondo cuando se inicia el juego.
-- `Game` gestiona la posición del jugador y las plantas. Sus métodos permiten
-  mover al jugador, actualizar el estado y recolectar.
-- En `growth.rs` se define el cálculo de colores y etapas de crecimiento.
+<details><summary>`draw_pink()`</summary>
+
+```rust
+#[wasm_bindgen]
+pub fn draw_pink() -> Result<(), JsValue> {
+    // ...dibuja fondo rosa
+}
+```
+
+</details>
+
+<details><summary>`Game`</summary>
+
+```rust
+#[wasm_bindgen]
+pub struct Game {
+    width: f64,
+    height: f64,
+    player_x: f64,
+    player_y: f64,
+    plants: Vec<Plant>,
+    collected: u32,
+}
+```
+
+</details>
+
+<details><summary>`growth.rs`</summary>
+
+```rust
+pub const MATURE_STAGE: u32 = 5;
+pub fn interval_for_species(species: &str) -> f64 { /* ... */ }
+pub fn update_plant(plant: &mut Plant, dt: f64) { /* ... */ }
+```
+
+</details>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,11 @@ site_name: Achtli
 site_description: Videojuego ambiental y documentación del proyecto
 site_author: Proyecto Achtli
 repo_url: https://github.com/LuisMAC2022/Achtli
+theme:
+  name: material
+markdown_extensions:
+  - admonition
+  - pymdownx.details
 nav:
   - Inicio: index.md
   - Decisiones: decisiones.md


### PR DESCRIPTION
## Summary
- use MkDocs Material and enable `pymdownx.details`
- add collapsible `<details>` sections for each documented function
- document decision to switch to the Material theme

## Testing
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*
- `mkdocs serve`

------
https://chatgpt.com/codex/tasks/task_e_68634f2b493483318e723c28663b77f8