### PR TITLE
Enable Material theme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       # 6) Construye la documentación con MkDocs
       - name: Build MkDocs site
         run: |
-          pip install mkdocs
+          pip install -r requirements.txt
           mkdocs build
 
       # 7) Despliega en GitHub Pages

--- a/decisiones/20250722-mkdocs-material.md
+++ b/decisiones/20250722-mkdocs-material.md
@@ -1,0 +1,16 @@
+# Habilitar Material y detalles
+
+## Resumen
+Se configuró MkDocs para usar el tema Material y se instaló `mkdocs-material`.
+Además se activó la extensión `pymdownx.details` para usar bloques desplegables.
+
+## Razonamiento
+El tema Material ofrece un estilo moderno y compatibilidad con componentes como
+`<details>` que mejoran la lectura.
+
+## Alternativas consideradas
+- Mantener el tema por defecto de MkDocs.
+- Implementar otro generador de documentación.
+
+## Sugerencias
+Aprovechar más extensiones de MkDocs Material para mejorar la documentación.

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -38,3 +38,4 @@ La siguiente lista incluye los archivos en la carpeta `decisiones`.
 - [20250719-madurez-overlay-colision.md](../decisiones/20250719-madurez-overlay-colision.md)
 - [20250720-mkdocs-integracion.md](../decisiones/20250720-mkdocs-integracion.md)
 - [20250721-documentar-funciones.md](../decisiones/20250721-documentar-funciones.md)
+- [20250722-mkdocs-material.md](../decisiones/20250722-mkdocs-material.md)

--- a/docs/funciones.md
+++ b/docs/funciones.md
@@ -5,25 +5,65 @@ Esta página describe brevemente las funciones disponibles en el proyecto.
 ## JavaScript
 
 ### js/game-logic.js
-- `seedColor()` y `matureColor()` generan colores aleatorios para las plantas.
-- `jsGrowthInterval(species)` define el tiempo de crecimiento según la especie.
-- `jsUpdatePlants(plants, dt)` actualiza el avance de todas las plantas.
-- `jsCollectAt(plants, x, y)` intenta recolectar una planta madura cercana.
-- `jsFindPlantAt(plants, x, y)` devuelve el índice de una planta en las coordenadas.
-- `createInitialPlants()` crea el conjunto inicial de plantas para el modo JS.
+<details>
+<summary><code>seedColor()</code> y <code>matureColor()</code></summary>
+Generan colores aleatorios para las plantas.
+</details>
+
+<details>
+<summary><code>jsGrowthInterval(species)</code></summary>
+Define el tiempo de crecimiento según la especie.
+</details>
+
+<details>
+<summary><code>jsUpdatePlants(plants, dt)</code></summary>
+Actualiza el avance de todas las plantas.
+</details>
+
+<details>
+<summary><code>jsCollectAt(plants, x, y)</code></summary>
+Intenta recolectar una planta madura cercana.
+</details>
+
+<details>
+<summary><code>jsFindPlantAt(plants, x, y)</code></summary>
+Devuelve el índice de una planta en las coordenadas.
+</details>
+
+<details>
+<summary><code>createInitialPlants()</code></summary>
+Crea el conjunto inicial de plantas para el modo JS.
+</details>
 
 ### js/ui.js
-- `setupUI(canvas, overlay, plantInfo, actions)` conecta los controles del
-  jugador y muestra información de cada planta.
+<details>
+<summary><code>setupUI(canvas, overlay, plantInfo, actions)</code></summary>
+Conecta los controles del jugador y muestra información de cada planta.
+</details>
 
 ### js/main.js
-- `start()` es el punto de entrada; carga el módulo wasm y comienza el ciclo de
-  dibujo.
-- Funciones internas como `movePlayer()` o `draw()` gestionan la lógica de
-  movimiento, colisiones y renderizado.
+<details>
+<summary><code>start()</code></summary>
+Carga el módulo wasm y comienza el ciclo de dibujo.
+</details>
+
+<details>
+<summary><code>movePlayer()</code> y <code>draw()</code></summary>
+Gestionan la lógica de movimiento, colisiones y renderizado.
+</details>
 
 ## Rust (wasm_game)
-- `draw_pink()` pinta el fondo cuando se inicia el juego.
-- `Game` gestiona la posición del jugador y las plantas. Sus métodos permiten
-  mover al jugador, actualizar el estado y recolectar.
-- En `growth.rs` se define el cálculo de colores y etapas de crecimiento.
+<details>
+<summary><code>draw_pink()</code></summary>
+Pinta el fondo cuando se inicia el juego.
+</details>
+
+<details>
+<summary><code>Game</code></summary>
+Gestiona la posición del jugador y las plantas. Sus métodos permiten mover al jugador, actualizar el estado y recolectar.
+</details>
+
+<details>
+<summary><code>growth.rs</code></summary>
+Define el cálculo de colores y etapas de crecimiento.
+</details>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,11 @@ site_name: Achtli
 site_description: Videojuego ambiental y documentación del proyecto
 site_author: Proyecto Achtli
 repo_url: https://github.com/LuisMAC2022/Achtli
+theme:
+  name: material
+markdown_extensions:
+  - admonition
+  - pymdownx.details
 nav:
   - Inicio: index.md
   - Decisiones: decisiones.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-material


### PR DESCRIPTION
## Summary
- switch MkDocs config to use the Material theme
- enable `pymdownx.details` extension for collapsible sections
- add collapsible `<details>` blocks in the function reference
- install dependencies through `requirements.txt` and workflow update
- record decision about moving to Material

## Testing
- `mkdocs build`
- `npm test` *(fails: TypeError: A dynamic import callback was invoked without --experimental-vm-modules)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68634f2b493483318e723c28663b77f8