### PR TITLE
Add docs crosslinks to functions

### DIFF
--- a/decisiones/20250723-links-funciones.md
+++ b/decisiones/20250723-links-funciones.md
@@ -1,0 +1,14 @@
+# Enlaces a funciones
+
+## Resumen
+Se añadieron hipervínculos a los archivos fuente en `docs/funciones.md` y se enlazaron las páginas principales hacia esa referencia.
+
+## Razonamiento
+Facilitar la navegación entre la documentación y el código del proyecto.
+
+## Alternativas consideradas
+- Mantener la documentación sin enlaces directos.
+- Usar una herramienta automática de documentación.
+
+## Sugerencias
+Actualizar los enlaces si se reorganizan los directorios o se renombran archivos.

--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -39,3 +39,6 @@ La siguiente lista incluye los archivos en la carpeta `decisiones`.
 - [20250720-mkdocs-integracion.md](../decisiones/20250720-mkdocs-integracion.md)
 - [20250721-documentar-funciones.md](../decisiones/20250721-documentar-funciones.md)
 - [20250722-mkdocs-material.md](../decisiones/20250722-mkdocs-material.md)
+- [20250723-links-funciones.md](../decisiones/20250723-links-funciones.md)
+
+Para conocer la implementación de cada sección del juego visita la [referencia de funciones](funciones.md).

--- a/docs/funciones.md
+++ b/docs/funciones.md
@@ -4,7 +4,7 @@ Esta página describe brevemente las funciones disponibles en el proyecto.
 
 ## JavaScript
 
-### js/game-logic.js
+### [js/game-logic.js](../js/game-logic.js)
 <details>
 <summary><code>seedColor()</code> y <code>matureColor()</code></summary>
 Generan colores aleatorios para las plantas.
@@ -35,13 +35,13 @@ Devuelve el índice de una planta en las coordenadas.
 Crea el conjunto inicial de plantas para el modo JS.
 </details>
 
-### js/ui.js
+### [js/ui.js](../js/ui.js)
 <details>
 <summary><code>setupUI(canvas, overlay, plantInfo, actions)</code></summary>
 Conecta los controles del jugador y muestra información de cada planta.
 </details>
 
-### js/main.js
+### [js/main.js](../js/main.js)
 <details>
 <summary><code>start()</code></summary>
 Carga el módulo wasm y comienza el ciclo de dibujo.
@@ -53,6 +53,8 @@ Gestionan la lógica de movimiento, colisiones y renderizado.
 </details>
 
 ## Rust (wasm_game)
+
+### [wasm_game/src/lib.rs](../wasm_game/src/lib.rs)
 <details>
 <summary><code>draw_pink()</code></summary>
 Pinta el fondo cuando se inicia el juego.
@@ -63,6 +65,7 @@ Pinta el fondo cuando se inicia el juego.
 Gestiona la posición del jugador y las plantas. Sus métodos permiten mover al jugador, actualizar el estado y recolectar.
 </details>
 
+### [wasm_game/src/growth.rs](../wasm_game/src/growth.rs)
 <details>
 <summary><code>growth.rs</code></summary>
 Define el cálculo de colores y etapas de crecimiento.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,8 @@ mantenimiento.  Decide si conservar el espejo en JS según el tiempo disponible 
 
 Abre `game.html` en un navegador moderno y usa las flechas para mover al personaje.
 
+Para conocer cada función disponible, revisa la [referencia de funciones](funciones.md).
+
 cambios por añadir:
 
 -> sustituir imagenes de baja resolucion con mapas de google (falta creacion de api de google)


### PR DESCRIPTION
## Summary
- link function names to source files in `docs/funciones.md`
- link back to the reference page from index and decisions
- record the decision to add links

## Testing
- `mkdocs build`
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686355b800308331b57fefb0a33cdd8a